### PR TITLE
Use sails new --no-frontend option

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -50,7 +50,7 @@ module.exports = function(cli) {
     cli.debug('generateAppFiles');
 
     return cli.exec('npm install').then(function() {
-      runExternalCommand(`${cli.cwd()}/${appName}/node_modules/.bin/sails`, ['new', 'api']).then(setupSails);
+      runExternalCommand(`${cli.cwd()}/${appName}/node_modules/.bin/sails`, ['new', 'api', '--no-frontend']).then(setupSails);
       runExternalCommand(`${cli.cwd()}/${appName}/node_modules/.bin/ember`, ['new', 'frontend', '--skip-git']).then(setupEmber);
     });
   }
@@ -58,12 +58,7 @@ module.exports = function(cli) {
   function setupSails() {
     cli.debug('setupSails');
 
-    cleanUpSails().then(function() {
-      cli.debug('Clean up sails finished.');
-    }).then(function() {
-      cli.debug('prepareSails started.');
-      prepareSails();
-    }).then(function() {
+    prepareSails().then(function() {
       cli.copyTemplates(`${cli.includedBasepath}/lib/templates/api`, `${apiDir}`, {clobber: true}, function(err) {
         if (err) { return cli.debug(err); }
         cli.debug('Sails templates copied without error.');
@@ -71,21 +66,6 @@ module.exports = function(cli) {
     }).done(function(){
       cli.banner(`${cli.includedBasepath}/lib/helpers/banner`);
     });
-  }
-
-  function cleanUpSails(){
-    cli.debug('cleanUpSails');
-
-    cli.rm(`${apiDir}/views`);
-    cli.rm(`${apiDir}/tasks`);
-    cli.rm(`${apiDir}/Gruntfile.js`);
-
-    var sailsPackages = ['rm', 'grunt', 'ejs', 'grunt-contrib-clean', 'grunt-contrib-concat',
-    'grunt-contrib-copy', 'grunt-contrib-cssmin', 'grunt-contrib-jst', 'grunt-contrib-less',
-    'grunt-contrib-uglify', 'grunt-contrib-watch', 'grunt-sails-linker', 'grunt-sync', 'grunt-contrib-coffee',
-    '--save'];
-
-    return runExternalCommand('npm', sailsPackages, { cwd: `${apiDir}` });
   }
 
   function prepareSails() {


### PR DESCRIPTION
Fixes #16.

Instead of creating a normal sails project and then cleaning it up afterwards,
now uses `--no-frontend` option to avoid creating unnecessary files and folders.

This works as-is, but `grunt`, `ejs` and `grunt-contrib-*` packages are still installed.  Issue https://github.com/balderdashy/sails-generate-new/issues/14 has been filed to hopefully address this on the sails.js end.