### PR TITLE
7 seedsrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,8 @@
   },
   "env": {
     "node": true,
-    "es6": true
+    "es6": true,
+    "mocha": true
   },
   "rules": {
     "no-comma-dangle": 2,

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Seeds is an acronym that stands for **S**ails **E**mber **E**mber-**D**ata **S**
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Soil Cli**
+**Seeds.js**
 
 - [Installation](#installation)
 - [Usage](#usage)

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,6 +7,7 @@ class SeedsCLI extends Cli {
 
   constructor(args, options) {
     super(args, options);
+    this.debugFlag = this.config.debug;
 
     this.nodeDir = join(this.cwd(), 'node_modules');
 
@@ -15,7 +16,6 @@ class SeedsCLI extends Cli {
 
     this.apiName = this.config.api.name;
     this.apiDir = join(this.cwd(), this.config.api.name);
-    this.debugFlag = this.config.debug;
   }
 
   get config() {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -17,6 +17,20 @@ class SeedsCLI extends Cli {
     this.apiDir = `${this.cwd()}/${this.apiName}`;
   }
 
+  get config() {
+    return require('rc')('seeds', {
+      api: {
+        name: 'api',
+        port: '1776'
+      },
+      frontend: {
+        name: 'frontend',
+        port: '4200'
+      },
+      debug: false
+    });
+  }
+
   runExternalCommand(command, args, options) {
     this.debug('runExternalCommand');
 
@@ -38,6 +52,10 @@ class SeedsCLI extends Cli {
       .fail(function(err) {
         this.debug(`fail ${command}`, err);
       });
+  }
+
+  static cli(args, options) {
+    return new SeedsCLI(args, options);
   }
 }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,20 +1,20 @@
 'use strict';
 
 var Cli = require('soil-cli');
+var join = require('path').join;
 
 class SeedsCLI extends Cli {
 
   constructor(args, options) {
     super(args, options);
 
-    this.nodeDir = `${this.cwd()}/node_modules`;
-    this.package = require('../package');
+    this.nodeDir = join(this.cwd(), 'node_modules');
 
-    this.feName = 'frontend';
-    this.feDir = `${this.cwd()}/${this.feName}`;
+    this.feName = this.config.frontend.name;
+    this.feDir =  join(this.cwd(), this.config.frontend.name);
 
-    this.apiName = 'api';
-    this.apiDir = `${this.cwd()}/${this.apiName}`;
+    this.apiName = this.config.api.name;
+    this.apiDir = join(this.cwd(), this.config.api.name);
   }
 
   get config() {
@@ -29,6 +29,14 @@ class SeedsCLI extends Cli {
       },
       debug: false
     });
+  }
+
+  get package() {
+    return require(join('..', 'package'));
+  }
+
+  cwd() {
+    return process.cwd();
   }
 
   runExternalCommand(command, args, options) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -15,6 +15,7 @@ class SeedsCLI extends Cli {
 
     this.apiName = this.config.api.name;
     this.apiDir = join(this.cwd(), this.config.api.name);
+    this.debugFlag = this.config.debug;
   }
 
   get config() {

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -41,6 +41,6 @@ module.exports = function(cli) {
       cli.error(`Currently generate only supports: ${implementedGenerators.join(' ')}`);
     }
   } else {
-    cli.error('You must be in a Seeds application to run the serve command.');
+    cli.error('You must be in a Seeds application to run the generate command.');
   }
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "mocha test/",
     "lint": "eslint -c .eslintrc lib/",
     "lint-staged": "git diff --diff-filter=ACMRTUXB --cached --name-only | grep '.*\\.js$' | grep -v 'node_modules' | grep -v 'test' | xargs eslint -c .eslintrc --ext .js --ext .js",
-    "doctoc": "doctoc README.md --title '**Soil Cli**' && if [ -f CONTRIBUTING.md ]; then doctoc CONTRIBUTING.md; fi && if [[ $(git diff --shortstat -- README.md 2> /dev/null | tail -n1) != '' || $(git diff --shortstat -- CONTRIBUTING.md 2> /dev/null | tail -n1) != '' ]]; then git add README.md CONTRIBUTING.md && git commit --no-verify -m'table of contents update'; fi",
+    "doctoc": "doctoc README.md --title '**Seeds.js**' && if [ -f CONTRIBUTING.md ]; then doctoc CONTRIBUTING.md; fi && if [[ $(git diff --shortstat -- README.md 2> /dev/null | tail -n1) != '' || $(git diff --shortstat -- CONTRIBUTING.md 2> /dev/null | tail -n1) != '' ]]; then git add README.md CONTRIBUTING.md && git commit --no-verify -m'table of contents update'; fi",
     "requireGitClean": "/bin/bash -c 'source ./scripts.sh && git_require_clean_work_tree'",
     "dmn": "dmn gen -f . && if [[ $(git diff --shortstat 2> /dev/null | tail -n1) != '' ]]; then git add .npmignore && git commit --no-verify -m'update npmignore'; fi",
     "gitPull": "git pull --rebase origin master",

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect;
-var Seeds = require('../index');
+var Seeds = require('../lib/cli');
 
 describe('Array', function(){
   describe('#indexOf()', function(){
@@ -19,8 +19,11 @@ describe('Seeds', function() {
     expect(Seeds).to.be.a('function');
   });
 
-  it('should return help if no args passed in', function() {
-    var cli = new Seeds('');
-    cli.command();
+  it('should have a default configuration', function() {
+    var cli = new Seeds();
+    expect(cli.config.api.name).to.equal('api');
+    expect(cli.config.api.port).to.equal('1776');
+    expect(cli.config.frontend.name).to.equal('frontend');
+    expect(cli.config.frontend.port).to.equal('4200');
   });
 });


### PR DESCRIPTION
adds config getter on seeds class and .seedsrc file. Closes #7 by adding this - however is not being utilized by the new/generate/serve commands yet. 

## Standards

Looks for a file named .seedsrc in the following locations.

  * command line arguments (parsed by minimist)
  * environment variables prefixed with `${appname}_`
    * or use "\_\_" to indicate nested properties <br/> _(e.g. `appname_foo__bar__baz` => `foo.bar.baz`)_
  * if you passed an option `--config file` then from that file
  * a local `.${appname}rc` or the first found looking in `./ ../ ../../ ../../../` etc.
  * `$HOME/.${appname}rc`
  * `$HOME/.${appname}/config`
  * `$HOME/.config/${appname}`
  * `$HOME/.config/${appname}/config`
  * `/etc/${appname}rc`
  * `/etc/${appname}/config`
  * the defaults object you passed in.

All configuration sources that were found will be flattened into one object,
so that sources **earlier** in this list override later ones.
