### PR TITLE
Update Ember to v2.4.1

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -1,5 +1,7 @@
+/*eslint no-undefined:0 */
 'use strict';
 
+var bower = require('bower');
 var join = require('path').join;
 var copy = require('fs-extra').copySync;
 var child = require('child_process');
@@ -49,7 +51,7 @@ module.exports = function (cli) {
 
     spawnSync(join(appDir, 'node_modules', '.bin', 'sails'), ['generate', 'seeds-frontend'], { cwd: feDir });
     spawnSync('npm', ['install'], { cwd: feDir });
-    copy(join(appDir, 'node_modules', 'sails-generate-seeds-frontend', 'templates', 'bower_components'), join(feDir, 'bower_components'));
+    bower.commands.install(undefined, undefined, { cwd: feDir });
     return;
   };
 

--- a/lib/templates/gitignore
+++ b/lib/templates/gitignore
@@ -15,3 +15,4 @@
 /connect.lock
 /coverage/*
 /builds
+/logs

--- a/lib/templates/package.json
+++ b/lib/templates/package.json
@@ -4,8 +4,8 @@
   "version": "1.0.0",
   "dependencies": {
     "sails-generate-seeds-backend": "~1.1.1",
-    "sails-generate-seeds-frontend": "~2.0.3",
-    "ember-cli": "^1.13.8",
+    "sails-generate-seeds-frontend": "~2.1.0",
+    "ember-cli": "~2.4.1",
     "sails": "^0.11.0"
   },
   "keywords": [

--- a/lib/templates/seedsrc
+++ b/lib/templates/seedsrc
@@ -1,17 +1,4 @@
 {
-  "apps": {
-    "sails": [
-      {
-        "name": "api",
-        "port": 1776
-      }
-    ],
-    "ember": [
-      {
-        "name": "frontend",
-        "port": 4200
-      }
-    ]
-  },
+  "apps": {"sails": [{ "name": "api", "port": 1776 }], "ember": [{ "name": "frontend", "port": 4200 }]},
   "debug": false
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seeds",
-  "version": "2.1.4",
+  "version": "2.2.0-beta.1",
   "description": "Seeds is a full-stack framework for rapidly building ambitious ember applications",
   "bin": {
     "seeds": "./bin/seeds"

--- a/src/commands/new.es6
+++ b/src/commands/new.es6
@@ -1,3 +1,5 @@
+/*eslint no-undefined:0 */
+const bower = require('bower');
 const join = require('path').join;
 const copy = require('fs-extra').copySync;
 const child = require('child_process');
@@ -47,7 +49,7 @@ module.exports = function(cli) {
 
     spawnSync(join(appDir, 'node_modules', '.bin', 'sails'), ['generate', 'seeds-frontend'], {cwd: feDir});
     spawnSync('npm', ['install'], {cwd: feDir});
-    copy(join(appDir, 'node_modules', 'sails-generate-seeds-frontend', 'templates', 'bower_components'), join(feDir, 'bower_components'));
+    bower.commands.install(undefined, undefined, {cwd: feDir});
     return;
   };
 

--- a/src/templates/gitignore
+++ b/src/templates/gitignore
@@ -15,3 +15,4 @@
 /connect.lock
 /coverage/*
 /builds
+/logs

--- a/src/templates/package.json
+++ b/src/templates/package.json
@@ -4,8 +4,8 @@
   "version": "1.0.0",
   "dependencies": {
     "sails-generate-seeds-backend": "~1.1.1",
-    "sails-generate-seeds-frontend": "~2.0.3",
-    "ember-cli": "^1.13.8",
+    "sails-generate-seeds-frontend": "~2.1.0",
+    "ember-cli": "~2.4.1",
     "sails": "^0.11.0"
   },
   "keywords": [

--- a/src/templates/seedsrc
+++ b/src/templates/seedsrc
@@ -1,17 +1,4 @@
 {
-  "apps": {
-    "sails": [
-      {
-        "name": "api",
-        "port": 1776
-      }
-    ],
-    "ember": [
-      {
-        "name": "frontend",
-        "port": 4200
-      }
-    ]
-  },
+  "apps": {"sails": [{ "name": "api", "port": 1776 }], "ember": [{ "name": "frontend", "port": 4200 }]},
   "debug": false
 }


### PR DESCRIPTION
Update Ember to 2.4.1, updates generate-seeds-frontend version to latest version with Ember 2.4.1 templates, remove hardcoded bower deps and replace with a bower install during ember install.