### PR TITLE
Change model generator to use scaffold-model generator

### DIFF
--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -7,7 +7,7 @@ var convertModels = require(join('..', 'helpers', 'convertModels'));
 module.exports = function (cli) {
   cli.debug('generate command start');
 
-  var implementedGenerators = ['scaffold', 'model', 'resource'];
+  var implementedGenerators = ['scaffold', 'model'];
   var generatorType = cli.args[1];
   var resourceName = cli.args[2];
   var attrsArr = cli.args.slice(3);
@@ -38,6 +38,9 @@ module.exports = function (cli) {
       var emberAttrs = convertModels.convert(attrsArr, 'ember');
       cli.debug(emberAttrs);
 
+      if (generatorType == 'model') {
+        generatorType = 'scaffold-model';
+      }
       var emberGenerateCommand = [cli.args[0], generatorType, resourceName];
       Array.prototype.push.apply(emberGenerateCommand, emberAttrs);
       cli.runExternalCommand(join(cli.feDir, 'node_modules', '.bin', 'ember'), emberGenerateCommand, { cwd: '' + cli.feDir });


### PR DESCRIPTION
Fixes model generator to use scaffold-model so that it always uses top level model folder with pods structure. Removes resource generator as I don't like what it creates and do not want to override it