### PR TITLE
add support to serve multiple ember apps with `seeds serve` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ logs
 dummy/
 node_modules
 npm-debug.log
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -19,3 +19,5 @@ npm-debug.log
 test/
 src/
 dummy/
+
+.idea

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -61,7 +61,8 @@ var SeedsCLI = (function (_Cli) {
           }],
           ember: [{
             name: 'frontend',
-            port: 4200
+            port: 4200,
+            reloadport: 49154
           }]
         },
         debug: false

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -19,6 +19,7 @@ module.exports = function (cli) {
       var appPath = join(cli.cwd, app.name);
       var port = app.port | 4200;
       var args = ['serve', '--port', port];
+
       if (app.reloadport) {
         args.push('--live-reload-port', app.reloadport);
       }

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -14,12 +14,16 @@ module.exports = function (cli) {
     for (var i = 0; i < cli.config.apps.ember.length; i++) {
       var app = cli.config.apps.ember[i];
 
-      cli.debug('starting to serve ember => ', app.name);
+      cli.debug('preparing to serve ember => ', app.name);
 
       var appPath = join(cli.cwd, app.name);
       var port = app.port | 4200;
+      var args = ['serve', '--port', port];
+      if (app.reloadport) {
+        args.push('--live-reload-port', app.reloadport);
+      }
 
-      cli.runExternalCommand(join(cli.nodeDir, '.bin', 'ember'), ['serve', '--port', port, '--live-reload-port', app.reload], { cwd: appPath });
+      cli.runExternalCommand(join(cli.nodeDir, '.bin', 'ember'), args, { cwd: appPath });
     }
   } else {
     cli.error('You must be in a Seeds application to run the serve command.');

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -10,7 +10,17 @@ module.exports = function (cli) {
     cli.debug('We\'re in a Seeds app.');
 
     cli.runExternalCommand(join(cli.nodeDir, '.bin', 'sails'), ['lift'], { cwd: cli.apiDir });
-    cli.runExternalCommand(join(cli.nodeDir, '.bin', 'ember'), ['serve'], { cwd: cli.feDir });
+
+    for (var i = 0; i < cli.config.apps.ember.length; i++) {
+      var app = cli.config.apps.ember[i];
+
+      cli.debug('starting to serve ember => ', app.name);
+
+      var appPath = '/work/tmp/seedstest/test-serve-admin/' + app.name;
+      var port = app.port | 4200;
+
+      cli.runExternalCommand(join(cli.nodeDir, '.bin', 'ember'), ['serve', '--port', port, '--live-reload-port', app.reload], { cwd: appPath });
+    }
   } else {
     cli.error('You must be in a Seeds application to run the serve command.');
   }

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -16,7 +16,7 @@ module.exports = function (cli) {
 
       cli.debug('starting to serve ember => ', app.name);
 
-      var appPath = '/work/tmp/seedstest/test-serve-admin/' + app.name;
+      var appPath = join(cli.cwd, app.name);
       var port = app.port | 4200;
 
       cli.runExternalCommand(join(cli.nodeDir, '.bin', 'ember'), ['serve', '--port', port, '--live-reload-port', app.reload], { cwd: appPath });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seeds",
-  "version": "2.3.0",
+  "version": "2.3.0-beta",
   "description": "Seeds is a full-stack framework for rapidly building ambitious ember applications",
   "bin": {
     "seeds": "./bin/seeds"
@@ -48,15 +48,22 @@
   },
   "homepage": "https://github.com/terminalvelocity/seeds.js",
   "dependencies": {
+    "babel": "^5.8.35",
     "bower": "^1.7.7",
+    "chai": "^2.3.0",
     "cli-table": "^0.3.1",
+    "dmn": "^1.0.10",
+    "doctoc": "^0.13.0",
+    "eslint": "^0.22.1",
     "fs-extra": "^0.19.0",
+    "ghooks": "^0.3.2",
     "lodash.partition": "^3.1.1",
-    "lodash.startswith": "^3.0.1",
+    "lodash.startswith": "^3.2.0",
     "mkdirp": "^0.5.1",
+    "mocha": "^2.4.5",
     "multiline": "^1.0.2",
-    "rc": "^1.0.3",
-    "resolve": "^1.1.6",
+    "rc": "^1.1.6",
+    "resolve": "^1.1.7",
     "soil-cli": "^1.3.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seeds",
-  "version": "2.3.0-beta",
+  "version": "2.3.0",
   "description": "Seeds is a full-stack framework for rapidly building ambitious ember applications",
   "bin": {
     "seeds": "./bin/seeds"
@@ -48,22 +48,15 @@
   },
   "homepage": "https://github.com/terminalvelocity/seeds.js",
   "dependencies": {
-    "babel": "^5.8.35",
     "bower": "^1.7.7",
-    "chai": "^2.3.0",
     "cli-table": "^0.3.1",
-    "dmn": "^1.0.10",
-    "doctoc": "^0.13.0",
-    "eslint": "^0.22.1",
     "fs-extra": "^0.19.0",
-    "ghooks": "^0.3.2",
     "lodash.partition": "^3.1.1",
-    "lodash.startswith": "^3.2.0",
+    "lodash.startswith": "^3.0.1",
     "mkdirp": "^0.5.1",
-    "mocha": "^2.4.5",
     "multiline": "^1.0.2",
-    "rc": "^1.1.6",
-    "resolve": "^1.1.7",
+    "rc": "^1.0.3",
+    "resolve": "^1.1.6",
     "soil-cli": "^1.3.6"
   },
   "devDependencies": {

--- a/src/cli.es6
+++ b/src/cli.es6
@@ -32,7 +32,8 @@ class SeedsCLI extends Cli {
         ember: [
           {
             name: 'frontend',
-            port: 4200
+            port: 4200,
+            reloadport: 49154
           }
         ]
       },

--- a/src/commands/serve.es6
+++ b/src/commands/serve.es6
@@ -17,6 +17,7 @@ module.exports = cli => {
       const appPath = join(cli.cwd, app.name);
       const port = app.port | 4200;
       let args = ['serve', '--port', port];
+
       if (app.reloadport) {
         args.push('--live-reload-port', app.reloadport);
       }

--- a/src/commands/serve.es6
+++ b/src/commands/serve.es6
@@ -8,7 +8,17 @@ module.exports = cli => {
     cli.debug('We\'re in a Seeds app.');
 
     cli.runExternalCommand(join(cli.nodeDir, '.bin', 'sails'), ['lift'], {cwd: cli.apiDir});
-    cli.runExternalCommand(join(cli.nodeDir, '.bin', 'ember'), ['serve'], {cwd: cli.feDir});
+
+    for (var i = 0; i < cli.config.apps.ember.length; i++) {
+      let app = cli.config.apps.ember[i];
+
+      cli.debug('starting to serve ember => ', app.name);
+
+      let appPath = `/work/tmp/seedstest/test-serve-admin/${app.name}`;
+      let port = app.port | 4200;
+
+      cli.runExternalCommand(join(cli.nodeDir, '.bin', 'ember'), ['serve', '--port', port, '--live-reload-port', app.reload], {cwd: appPath});
+    }
   } else {
     cli.error('You must be in a Seeds application to run the serve command.');
   }

--- a/src/commands/serve.es6
+++ b/src/commands/serve.es6
@@ -14,7 +14,7 @@ module.exports = cli => {
 
       cli.debug('starting to serve ember => ', app.name);
 
-      let appPath = `/work/tmp/seedstest/test-serve-admin/${app.name}`;
+      let appPath = join(cli.cwd, app.name);
       let port = app.port | 4200;
 
       cli.runExternalCommand(join(cli.nodeDir, '.bin', 'ember'), ['serve', '--port', port, '--live-reload-port', app.reload], {cwd: appPath});

--- a/src/commands/serve.es6
+++ b/src/commands/serve.es6
@@ -10,18 +10,20 @@ module.exports = cli => {
     cli.runExternalCommand(join(cli.nodeDir, '.bin', 'sails'), ['lift'], {cwd: cli.apiDir});
 
     for (var i = 0; i < cli.config.apps.ember.length; i++) {
-      let app = cli.config.apps.ember[i];
+      const app = cli.config.apps.ember[i];
 
-      cli.debug('starting to serve ember => ', app.name);
+      cli.debug('preparing to serve ember => ', app.name);
 
-      let appPath = join(cli.cwd, app.name);
-      let port = app.port | 4200;
+      const appPath = join(cli.cwd, app.name);
+      const port = app.port | 4200;
+      let args = ['serve', '--port', port];
+      if (app.reloadport) {
+        args.push('--live-reload-port', app.reloadport);
+      }
 
-      cli.runExternalCommand(join(cli.nodeDir, '.bin', 'ember'), ['serve', '--port', port, '--live-reload-port', app.reload], {cwd: appPath});
+      cli.runExternalCommand(join(cli.nodeDir, '.bin', 'ember'), args, {cwd: appPath});
     }
   } else {
     cli.error('You must be in a Seeds application to run the serve command.');
   }
 };
-
-


### PR DESCRIPTION
@jhliberty take a peek and let me know what you think.  it's pretty basic though :) 

this assumes the following for the ember config block in `.seedsrc`:

```
"ember": [
  {
    "name": "frontend",
    "port": 4200,
    "reloadport": 65533
  },
  {
    "name": "admin",
    "port": 4201,
    "reloadport": 65534
  }
]
```